### PR TITLE
fix: additional setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,6 +195,10 @@ Make sure you have the `nightly` toolchain installed locally:
 
 ```bash
 rustup toolchain install nightly
+cargo install --force cbindgen
+rustup target add wasm32-unknown-unknown
+cd parser/tools
+npm install
 ```
 
 After all the requirements are met, you can then run:


### PR DESCRIPTION
These are the steps I had to run on OSX to get it to build. I am not sure if this is cross platform though, the part about wasm with `unknown` in it particularly felt like maybe I was doing something wrong.