### PR TITLE
Use TypedArrays instead of Nodejs' Buffer

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,11 +190,24 @@ If you want to build it locally, you need the following tools:
 
 - [cargo-make][cargo-make]
 - Rust toolchain - You can install it via [rustup].
+- [rust-cbindgen](https://github.com/mozilla/cbindgen)
 
 Make sure you have the `nightly` toolchain installed locally:
 
 ```bash
 rustup toolchain install nightly
+```
+
+Make sure you have the `wasm32-unknown-unknown` target:
+
+```bash
+rustup target add wasm32-unknown-unknown
+```
+
+Install npm deps inside parser/tools:
+
+```bash
+(cd parser/tools && npm i)
 ```
 
 After all the requirements are met, you can then run:

--- a/parser/tools/postbuild-wasm.mjs
+++ b/parser/tools/postbuild-wasm.mjs
@@ -213,7 +213,7 @@ async function generateEmbedded(code, profile) {
 
       const replacement = parseExpression(`
         function loadWASM() {
-          return Buffer.from('${payload}', 'base64');
+          return Uint8Array.from(globalThis.atob('${payload}'), c => c.codePointAt(0))
         }
       `)
 


### PR DESCRIPTION
Closes #4 

This lets this parser be used from more environments, namely browsers. #4 has more context.

https://sindresorhus.com/blog/goodbye-nodejs-buffer has some context on why we should move on from NodeJS buffers.

Probably also closes #3, because I updated the instructions as a side effect and didn't see that PR.